### PR TITLE
Correct use ERRORLEVEL in conda scripts for Windows

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,4 +1,8 @@
 call "%ONEAPI_ROOT%compiler\latest\env\vars.bat"
+IF ERRORLEVEL 1 exit 1
+REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
+set ERRORLEVEL=
+
 set "CC=dpcpp-cl.exe"
 set "CXX=dpcpp-cl.exe"
 

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -14,11 +14,11 @@ cmake -G Ninja ^
     "-DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "%SRC_DIR%/oneapi_wrapper"
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1
 
 ninja -n
 ninja install
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1
 
 cd ..
 
@@ -33,4 +33,4 @@ set "DPPL_ONEAPI_INTERFACE_INCLDIR=%LIBRARY_PREFIX%/include"
 "%PYTHON%" setup.py clean --all
 "%PYTHON%" setup.py build
 "%PYTHON%" setup.py install
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -18,11 +18,11 @@ cmake -G Ninja ^
     "-DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%" ^
     "-DDPCPP_ROOT=%DPCPP_ROOT%" ^
     "%SRC_DIR%/oneapi_wrapper"
-IF ERRORLEVEL 1 exit 1
+IF %ERRORLEVEL% NEQ 0 exit 1
 
 ninja -n
 ninja install
-IF ERRORLEVEL 1 exit 1
+IF %ERRORLEVEL% NEQ 0 exit 1
 
 cd ..
 
@@ -37,4 +37,4 @@ set "DPPL_ONEAPI_INTERFACE_INCLDIR=%LIBRARY_PREFIX%/include"
 "%PYTHON%" setup.py clean --all
 "%PYTHON%" setup.py build
 "%PYTHON%" setup.py install
-IF ERRORLEVEL 1 exit 1
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,13 +1,13 @@
 call "%ONEAPI_ROOT%/compiler/latest/env/vars.bat"
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1
 
 @echo on
 
 "%PYTHON%" -c "import dppl"
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1
 
 "%PYTHON%" -c "import dppl.ocldrv"
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1
 
 "%PYTHON%" -m unittest -v dppl.tests
-IF %ERRORLEVEL% NEQ 0 exit 1
+IF ERRORLEVEL 1 exit 1

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -1,5 +1,7 @@
 call "%ONEAPI_ROOT%/compiler/latest/env/vars.bat"
 IF ERRORLEVEL 1 exit 1
+REM conda uses %ERRORLEVEL% but FPGA scripts can set it. So it should be reseted.
+set ERRORLEVEL=
 
 @echo on
 

--- a/conda-recipe/run_test.bat
+++ b/conda-recipe/run_test.bat
@@ -6,10 +6,10 @@ set ERRORLEVEL=
 @echo on
 
 "%PYTHON%" -c "import dppl"
-IF ERRORLEVEL 1 exit 1
+IF %ERRORLEVEL% NEQ 0 exit 1
 
 "%PYTHON%" -c "import dppl.ocldrv"
-IF ERRORLEVEL 1 exit 1
+IF %ERRORLEVEL% NEQ 0 exit 1
 
 "%PYTHON%" -m unittest -v dppl.tests
-IF ERRORLEVEL 1 exit 1
+IF %ERRORLEVEL% NEQ 0 exit 1


### PR DESCRIPTION
When I build conda package on Windows in my local environment it fails on tests.
It happens because oneAPI env activation script (part related to FPGA) does `set ERRORLEVEL=1`.
As mentioned in this [article](https://devblogs.microsoft.com/oldnewthing/20080926-00/?p=20743) in cmd.exe scripts
`IF ERRORLEVEL 1 ...` checks the last exit value but `IF %ERROLEVEL% NEQ 0 ...` checks env variable. The env variable does not relate to last exit status. I think it is error in oneAPI and conda scripts to use env variable instead of exit value.

Current CI works without this modifications but my local env does not work without it.

Also, I have tested it with my last commit on branch beta/2021. When I test in master it crashes on python -c "import dppl". It does not relate to this modifications. Just there is an issue between beta/2021 and current master.