### PR TITLE
Change static variables to static pointers

### DIFF
--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -105,17 +105,20 @@ class QMgrHelper
 public:
     static std::vector<cl::sycl::queue>&   cpu_queues_()
     {
-        static std::vector<cl::sycl::queue>* cpu_queues = QMgrHelper::init_queues(info::device_type::cpu);
+        static std::vector<cl::sycl::queue>* cpu_queues =
+            QMgrHelper::init_queues(info::device_type::cpu);
         return *cpu_queues;
     }
     static std::vector<cl::sycl::queue>&   gpu_queues_()
     {
-        static std::vector<cl::sycl::queue>* gpu_queues = QMgrHelper::init_queues(info::device_type::gpu);
+        static std::vector<cl::sycl::queue>* gpu_queues =
+            QMgrHelper::init_queues(info::device_type::gpu);
         return *gpu_queues;
     }
     static std::vector<cl::sycl::queue>& active_queues_()
     {
-        thread_local static std::vector<cl::sycl::queue>* active_queues = new std::vector<cl::sycl::queue>({default_selector()});
+        thread_local static std::vector<cl::sycl::queue>* active_queues =
+            new std::vector<cl::sycl::queue>({default_selector()});
         return *active_queues;
     }
 
@@ -137,7 +140,7 @@ public:
     static cl::sycl::vector_class<cl::sycl::queue>*
     init_queues (info::device_type device_ty)
     {
-        std::vector<cl::sycl::queue>* queues = new std::vector<cl::sycl::queue>();
+        auto queues = new std::vector<cl::sycl::queue>();
         for(auto d : device::get_devices(device_ty))
             queues->emplace_back(d);
         return queues;

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -103,19 +103,24 @@ void error_reporter (const std::string & msg)
 class QMgrHelper
 {
 public:
-    static std::vector<cl::sycl::queue>&   cpu_queues_()
+    static std::vector<cl::sycl::queue>&
+    cpu_queues_ ()
     {
         static std::vector<cl::sycl::queue>* cpu_queues =
             QMgrHelper::init_queues(info::device_type::cpu);
         return *cpu_queues;
     }
-    static std::vector<cl::sycl::queue>&   gpu_queues_()
+
+    static std::vector<cl::sycl::queue>&
+    gpu_queues_ ()
     {
         static std::vector<cl::sycl::queue>* gpu_queues =
             QMgrHelper::init_queues(info::device_type::gpu);
         return *gpu_queues;
     }
-    static std::vector<cl::sycl::queue>& active_queues_()
+
+    static std::vector<cl::sycl::queue>&
+    active_queues_ ()
     {
         thread_local static std::vector<cl::sycl::queue>* active_queues =
             new std::vector<cl::sycl::queue>({default_selector()});
@@ -147,9 +152,13 @@ public:
     }
 };
 
+// make function call like access to variable
+// it is for minimizing code changes during replacing static vars with functions
+// it could be refactored by replacing variable with function call
+// scope of this variables is only this file
+#define cpu_queues    cpu_queues_()
+#define gpu_queues    gpu_queues_()
 #define active_queues active_queues_()
-#define cpu_queues cpu_queues_()
-#define gpu_queues gpu_queues_()
 
 /*!
  * Allocates a new copy of the present top of stack queue, which can be the

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -105,18 +105,18 @@ class QMgrHelper
 public:
     static std::vector<cl::sycl::queue>&   cpu_queues_()
     {
-        static std::vector<cl::sycl::queue> cpu_queues = QMgrHelper::init_queues(info::device_type::cpu);
-        return cpu_queues;
+        static std::vector<cl::sycl::queue>* cpu_queues = QMgrHelper::init_queues(info::device_type::cpu);
+        return *cpu_queues;
     }
     static std::vector<cl::sycl::queue>&   gpu_queues_()
     {
-        static std::vector<cl::sycl::queue> gpu_queues = QMgrHelper::init_queues(info::device_type::gpu);
-        return gpu_queues;
+        static std::vector<cl::sycl::queue>* gpu_queues = QMgrHelper::init_queues(info::device_type::gpu);
+        return *gpu_queues;
     }
     static std::vector<cl::sycl::queue>& active_queues_()
     {
-        thread_local static std::vector<cl::sycl::queue> active_queues = {default_selector()};
-        return active_queues;
+        thread_local static std::vector<cl::sycl::queue>* active_queues = new std::vector<cl::sycl::queue>({default_selector()});
+        return *active_queues;
     }
 
     static __dppl_give DPPLSyclQueueRef
@@ -134,12 +134,12 @@ public:
     static void
     popSyclQueue ();
 
-    static cl::sycl::vector_class<cl::sycl::queue>
+    static cl::sycl::vector_class<cl::sycl::queue>*
     init_queues (info::device_type device_ty)
     {
-        std::vector<cl::sycl::queue> queues;
+        std::vector<cl::sycl::queue>* queues = new std::vector<cl::sycl::queue>();
         for(auto d : device::get_devices(device_ty))
-            queues.emplace_back(d);
+            queues->emplace_back(d);
         return queues;
     }
 };

--- a/backends/source/dppl_sycl_queue_interface.cpp
+++ b/backends/source/dppl_sycl_queue_interface.cpp
@@ -148,16 +148,6 @@ public:
 #define cpu_queues cpu_queues_()
 #define gpu_queues gpu_queues_()
 
-// Initialize the active_queue with the default queue
-// thread_local std::vector<cl::sycl::queue> QMgrHelper::active_queues
-//     = {default_selector()};
-
-// std::vector<cl::sycl::queue> QMgrHelper::cpu_queues
-//     = QMgrHelper::init_queues(info::device_type::cpu);
-
-// std::vector<cl::sycl::queue> QMgrHelper::gpu_queues
-//     = QMgrHelper::init_queues(info::device_type::gpu);
-
 /*!
  * Allocates a new copy of the present top of stack queue, which can be the
  * default queue and returns to caller. The caller owns the pointer and is


### PR DESCRIPTION
On Windows static variables construction and destruction cause crashes. I think it is because it should be called in specific order. With static variables the order is undefined.

Now the static variables are constructed at the first access to this variables. The first access happens after all necessary initializations.
Also I think destruction should happen in correct order. As we have no explicit destruction function it is hard to control where static global variables will be deleted. So the variables are changed to pointers and we do not call destruction for them at all. As they should exist to the end of the application it is ok to not destruct them and allow OS to clean its memory.
