### PR TITLE
Rename _usm_type parameter from context to syclobj

### DIFF
--- a/dppl/_memory.pyx
+++ b/dppl/_memory.pyx
@@ -78,26 +78,26 @@ cdef class Memory:
         return "<Intel(R) USM allocated memory block of {} bytes at {}>" \
             .format(self.nbytes, hex(<object>(<Py_ssize_t>self.memory_ptr)))
 
-    def _usm_type(self, context=None):
+    def _usm_type(self, syclobj=None):
         cdef const char* kind
         cdef SyclContext ctx
         cdef SyclQueue q
-        if context is None:
+        if syclobj is None:
             ctx = self._context
             kind = DPPLUSM_GetPointerType(self.memory_ptr,
                                           ctx.get_context_ref())
-        elif isinstance(context, SyclContext):
-            ctx = <SyclContext>(context)
+        elif isinstance(syclobj, SyclContext):
+            ctx = <SyclContext>(syclobj)
             kind = DPPLUSM_GetPointerType(self.memory_ptr,
                                           ctx.get_context_ref())
-        elif isinstance(context, SyclQueue):
-            q = <SyclQueue>(context)
+        elif isinstance(syclobj, SyclQueue):
+            q = <SyclQueue>(syclobj)
             ctx = q.get_sycl_context()
             kind = DPPLUSM_GetPointerType(self.memory_ptr,
                                           ctx.get_context_ref())
         else:
-            raise ValueError("sycl_context keyword can be either None, "
-                             "or an instance of dppl.SyclConext")
+            raise ValueError("syclobj keyword can be either None, "
+                             "or an instance of SyclConext or SyclQueue")
         return kind.decode('UTF-8')
 
 

--- a/dppl/tests/dppl_tests/test_sycl_usm.py
+++ b/dppl/tests/dppl_tests/test_sycl_usm.py
@@ -55,7 +55,7 @@ class TestMemory (unittest.TestCase):
 
             current_queue = dppl.get_current_queue()
             # type as view from current queue
-            usm_type = mobj._usm_type(context=current_queue)
+            usm_type = mobj._usm_type(current_queue)
             # type can be unknown if current queue is
             # not in the same SYCL context
             self.assertTrue(usm_type in ['unknown', 'shared'])
@@ -68,7 +68,7 @@ class TestMemory (unittest.TestCase):
             usm_type = mobj._usm_type()
             self.assertEqual(usm_type, 'shared')
             current_queue = dppl.get_current_queue()
-            usm_type = mobj._usm_type(context=current_queue)
+            usm_type = mobj._usm_type(current_queue)
             self.assertTrue(usm_type in ['unknown', 'shared'])
 
 


### PR DESCRIPTION
Parameter `context` could be `None`, `SyclContext` or `SyclQueue`. 
Name `context` confuses.