### PR TITLE
Fix using dppl.has_sycl_platforms() and dppl.has_gpu_queues() functions in skipIf()

### DIFF
--- a/dppl/tests/dppl_tests/test_sycl_queue_manager.py
+++ b/dppl/tests/dppl_tests/test_sycl_queue_manager.py
@@ -27,12 +27,12 @@ import dppl
 import unittest
 
 class TestGetNumPlatforms (unittest.TestCase):
-    @unittest.skipIf(not dppl.has_sycl_platforms, "No SYCL platforms available")
+    @unittest.skipIf(not dppl.has_sycl_platforms(), "No SYCL platforms available")
     def test_dppl_get_num_platforms (self):
         if(dppl.has_sycl_platforms):
             self.assertGreaterEqual(dppl.get_num_platforms(), 1)
 
-@unittest.skipIf(not dppl.has_sycl_platforms, "No SYCL platforms available")
+@unittest.skipIf(not dppl.has_sycl_platforms(), "No SYCL platforms available")
 class TestDumpMethods (unittest.TestCase):
     def test_dppl_dump (self):
         try:
@@ -47,7 +47,7 @@ class TestDumpMethods (unittest.TestCase):
         except Exception:
             self.fail("Encountered an exception inside dump_device_info().")
 
-@unittest.skipIf(not dppl.has_sycl_platforms, "No SYCL platforms available")
+@unittest.skipIf(not dppl.has_sycl_platforms(), "No SYCL platforms available")
 class TestDPPLIsInDPPLCtxt (unittest.TestCase):
 
     def test_is_in_dppl_ctxt_outside_device_ctxt (self):
@@ -64,13 +64,13 @@ class TestDPPLIsInDPPLCtxt (unittest.TestCase):
             self.assertTrue(dppl.is_in_dppl_ctxt())
         self.assertFalse(dppl.is_in_dppl_ctxt())
 
-@unittest.skipIf(not dppl.has_sycl_platforms, "No SYCL platforms available")
+@unittest.skipIf(not dppl.has_sycl_platforms(), "No SYCL platforms available")
 class TestGetCurrentQueueInMultipleThreads (unittest.TestCase):
 
     def test_num_current_queues_outside_with_clause (self):
         self.assertEqual(dppl.get_num_activated_queues(), 0)
 
-    @unittest.skipIf(not dppl.has_gpu_queues, "No GPU platforms available")
+    @unittest.skipIf(not dppl.has_gpu_queues(), "No GPU platforms available")
     def test_num_current_queues_inside_with_clause (self):
         with dppl.device_context(dppl.device_type.cpu):
             self.assertEqual(dppl.get_num_activated_queues(), 1)
@@ -78,7 +78,7 @@ class TestGetCurrentQueueInMultipleThreads (unittest.TestCase):
                 self.assertEqual(dppl.get_num_activated_queues(), 2)
         self.assertEqual(dppl.get_num_activated_queues(), 0)
 
-    @unittest.skipIf(not dppl.has_gpu_queues, "No GPU platforms available")
+    @unittest.skipIf(not dppl.has_gpu_queues(), "No GPU platforms available")
     def test_num_current_queues_inside_threads (self):
         from threading import Thread, local
         def SessionThread (self):

--- a/dppl/tests/dppl_tests/test_sycl_queue_manager.py
+++ b/dppl/tests/dppl_tests/test_sycl_queue_manager.py
@@ -57,6 +57,7 @@ class TestDPPLIsInDPPLCtxt (unittest.TestCase):
         with dppl.device_context(dppl.device_type.gpu):
             self.assertTrue(dppl.is_in_dppl_ctxt())
 
+    @unittest.skipIf(not dppl.has_cpu_queues(), "No CPU platforms available")
     def test_is_in_dppl_ctxt_inside_nested_device_ctxt (self):
         with dppl.device_context(dppl.device_type.cpu):
             with dppl.device_context(dppl.device_type.gpu):
@@ -71,6 +72,7 @@ class TestGetCurrentQueueInMultipleThreads (unittest.TestCase):
         self.assertEqual(dppl.get_num_activated_queues(), 0)
 
     @unittest.skipIf(not dppl.has_gpu_queues(), "No GPU platforms available")
+    @unittest.skipIf(not dppl.has_cpu_queues(), "No CPU platforms available")
     def test_num_current_queues_inside_with_clause (self):
         with dppl.device_context(dppl.device_type.cpu):
             self.assertEqual(dppl.get_num_activated_queues(), 1)
@@ -79,6 +81,7 @@ class TestGetCurrentQueueInMultipleThreads (unittest.TestCase):
         self.assertEqual(dppl.get_num_activated_queues(), 0)
 
     @unittest.skipIf(not dppl.has_gpu_queues(), "No GPU platforms available")
+    @unittest.skipIf(not dppl.has_cpu_queues(), "No CPU platforms available")
     def test_num_current_queues_inside_threads (self):
         from threading import Thread, local
         def SessionThread (self):

--- a/dppl/tests/dppl_tests/test_sycl_usm.py
+++ b/dppl/tests/dppl_tests/test_sycl_usm.py
@@ -43,6 +43,7 @@ class TestMemory (unittest.TestCase):
         # Without context
         self.assertEqual(mobj._usm_type(), 'shared')
 
+    @unittest.skipIf(not dppl.has_cpu_queues(), "No CPU platforms available")
     def test_memory_cpu_context (self):
         mobj = self._create_memory()
 
@@ -60,6 +61,7 @@ class TestMemory (unittest.TestCase):
             # not in the same SYCL context
             self.assertTrue(usm_type in ['unknown', 'shared'])
 
+    @unittest.skipIf(not dppl.has_gpu_queues(), "No GPU platforms available")
     def test_memory_gpu_context (self):
         mobj = self._create_memory()
 


### PR DESCRIPTION
Checking for `not dppl.has_sycl_platforms` always returns `False`.
Also this PR adds skipIf() for new tests.